### PR TITLE
Fixing "[usbip_vhci_attach_device2] write_sysfs_attribute failed"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,7 @@ version: 1.0.0
 description: USBIP Client Handler to attach USBIP devices to Hassio
 image: irakhlin/hassio-{arch}-usbip-mounter
 init: false
+full_access: true
 arch:
 - aarch64
 - amd64

--- a/rootfs/etc/cont-init.d/create_devices.sh
+++ b/rootfs/etc/cont-init.d/create_devices.sh
@@ -25,6 +25,7 @@ fi
 if ! bashio::fs.file_exists "${mount_script}"; then
   touch ${mount_script}
   chmod +x ${mount_script}
+  echo 'mount -o remount -t sysfs sysfs /sys' > "${mount_script}"
   echo '#!/command/with-contenv bashio' > "${mount_script}"
   echo 'set -x' >> "${mount_script}"
   for device in $(bashio::config 'devices|keys'); do

--- a/rootfs/etc/cont-init.d/create_devices.sh
+++ b/rootfs/etc/cont-init.d/create_devices.sh
@@ -25,9 +25,9 @@ fi
 if ! bashio::fs.file_exists "${mount_script}"; then
   touch ${mount_script}
   chmod +x ${mount_script}
-  echo 'mount -o remount -t sysfs sysfs /sys' > "${mount_script}"
   echo '#!/command/with-contenv bashio' > "${mount_script}"
   echo 'set -x' >> "${mount_script}"
+  echo 'mount -o remount -t sysfs sysfs /sys' >> "${mount_script}"
   for device in $(bashio::config 'devices|keys'); do
     server_address=$(bashio::config "devices[${device}].server_address")
     bus_id=$(bashio::config "devices[${device}].bus_id")


### PR DESCRIPTION
Disclaimer: I am playing with HA for less than 12 hours, but run into not able to use usbip. I am not very familiar yet with HA architecture and neccessity of "full_access" and I will probably need to study this more.

However, simply modifing mounting script (add remount of sysfs) before attaching usb over ip seems does the job.
Add-on on HA has to have protective mode **disabled**.

Attached usb works without any issues.
Then usb is successfully attached:

> s6-rc: info: service s6rc-oneshot-runner: starting
> s6-rc: info: service s6rc-oneshot-runner successfully started
> s6-rc: info: service fix-attrs: starting
> s6-rc: info: service fix-attrs successfully started
> s6-rc: info: service legacy-cont-init: starting
> cont-init: info: running /etc/cont-init.d/create_devices.sh
> [14:16:54] INFO: Adding device from server 192.168.16.3 on bus 1-1.3
> cont-init: info: /etc/cont-init.d/create_devices.sh exited 0
> cont-init: info: running /etc/cont-init.d/load_modules.sh
> cont-init: info: /etc/cont-init.d/load_modules.sh exited 0
> s6-rc: info: service legacy-cont-init successfully started
> s6-rc: info: service legacy-services: starting
> services-up: info: copying legacy longrun usbip (no readiness notification)
> services-up: info: copying legacy longrun usbipd (no readiness notification)
> s6-rc: info: service legacy-services successfully started
> [14:16:54] INFO: Starting the USBIP Daemon
> usbipd: info: starting usbipd (usbip-utils 2.0)
> usbipd: info: listening on 0.0.0.0:3240
> usbipd: info: listening on :::3240
> [14:16:54] INFO: Attaching usbip devices`